### PR TITLE
Ensure $I contains an Int

### DIFF
--- a/cradle.ps1
+++ b/cradle.ps1
@@ -70,6 +70,10 @@ $methods = @("remotethreadapc", "remotethreadcontext", "processhollowing", "modu
 if ($methods.Contains($A)) {
     try {
         $I = (Get-Process $I -ErrorAction Stop).Id
+        # if multiple processes exist with the same name, arbitrary select the first one
+        if ($I -is [array]) {
+            $I = $I[0]
+        }
     }
     catch {
         $I = 0


### PR DESCRIPTION
By default `$I` is set to `explorer` but if multiple instances are running, `$I` type is an array which break the code. The fix check if `$I` is an array and set the PID to the first value to ensure an int is passed to the assembly.