### PR TITLE
Removed repetitive line in encrypt.py

### DIFF
--- a/encrypt.py
+++ b/encrypt.py
@@ -79,7 +79,6 @@ if __name__ == '__main__':
 	if args.algorithm == 'aes':
 		iv = os.urandom(16)
 		ctx = AES(args.password, iv)
-		enc = ctx.encrypt(shellcode)
 	elif args.algorithm == 'xor':
 		ctx = XOR(args.password)
 


### PR DESCRIPTION
I'm not sure, but you are calling `enc = ctx.encrypt(shellcode)` two times in the default case which IMHO seems like a repetition.